### PR TITLE
Time keys

### DIFF
--- a/viz/2/js/app.js
+++ b/viz/2/js/app.js
@@ -269,9 +269,9 @@ function app() {
             maxY = mapView.height;
         };
 
-        d.drawTimechart= drawTimechart;
-        d.replaceTimechart = replaceTimechart;
-        d.updateTimeNeedle = updateTimeNeedle;
+        // d.drawTimechart= drawTimechart;
+        // d.replaceTimechart = replaceTimechart;
+        // d.updateTimeNeedle = updateTimeNeedle;
         d.setUIDateTime = setUIDateTime;
         d.getUIDateTime = getUIDateTime;
         d.getAltitudeBand = getAltitudeBand;

--- a/viz/2/js/app.js
+++ b/viz/2/js/app.js
@@ -60,11 +60,13 @@ function app() {
         var outdataByRadar = {};
         var timeKeys = [];
         for (var i=0; i<rows.length; i++) {
+            if (!timeKeys.includes(rows[i].interval_start_time)) {
+                timeKeys.push(rows[i].interval_start_time);
+            }
             if (outdataByAltandTime.hasOwnProperty(rows[i].altitude_band)) {
                 if (outdataByAltandTime[rows[i].altitude_band].hasOwnProperty(rows[i].interval_start_time)) {
                     outdataByAltandTime[rows[i].altitude_band][rows[i].interval_start_time].push(rows[i]);
                 } else {
-                    timeKeys.push(rows[i].interval_start_time);
                     outdataByAltandTime[rows[i].altitude_band][rows[i].interval_start_time] = [rows[i]];
                 }
             } else {
@@ -76,7 +78,6 @@ function app() {
                     outdataByRadar[rows[i].radar_id][rows[i].altitude_band].push(rows[i]);
                 } else {
                     outdataByRadar[rows[i].radar_id][rows[i].altitude_band] = [rows[i]];
-
                 }
             } else {
                 var band = rows[i].altitude_band;
@@ -84,6 +85,7 @@ function app() {
                 outdataByRadar[rows[i].radar_id][band] = [rows[i]];
             }
         }
+        timeKeys.sort(); // Not guaranteed that timestamps are added in order
         return {dataByTime: outdataByAltandTime, dataByRadar: outdataByRadar, keys: timeKeys};
     }
 


### PR DESCRIPTION
Discovered for a dataset with gaps in the dates.

There were two issues:

1. Since the keys were added in the dataByAltandTime loop, each time key was added for every altitude band (e.g. twice), rather than having unique keys.
2. If one radar had a datetime missing, it was only added after all the other dates => keys not in order.

`timeKeys` is now created in its own if statement => **keys in order and unique**. I tested this for both visualizations and they still work.